### PR TITLE
CWAP-212: Simplified the feature toggle definitions so that they're easier to query.

### DIFF
--- a/databases/app-config-sync/doc-definitions.js
+++ b/databases/app-config-sync/doc-definitions.js
@@ -1,10 +1,9 @@
 function() {
   // Regex for feature toggle names that's shared between a couple of fragments.
-  var featureToggleNamePattern = '[a-z0-9_-]+';
-  var featureToggleNameRegex = new RegExp('^' + featureToggleNamePattern + '$');
+  var featureToggleNameRegex = /^[a-z0-9_-]+$/;
 
   return {
-    featureReleaseToggleDefinitions: importDocumentDefinitionFragment('fragment-feature-release-toggle-definitions.js')(),
+    featureReleaseToggleDefinitions: importDocumentDefinitionFragment('fragment-feature-release-toggle-definitions.js'),
     featureReleaseToggles: importDocumentDefinitionFragment('fragment-feature-release-toggles.js'),
     paymentNotificationTemplates: importDocumentDefinitionFragment('fragment-payment-notification-templates.js'),
     paymentProcessingFeeTemplate: importDocumentDefinitionFragment('fragment-payment-processing-fee-template.js'),

--- a/databases/app-config-sync/fragment-feature-release-toggle-definitions.js
+++ b/databases/app-config-sync/fragment-feature-release-toggle-definitions.js
@@ -10,34 +10,37 @@
   },
   propertyValidators: {
     toggles: {
-      // A list of actions that are available to the recipient of the notification
+      // A list of the feature toggles defined for the application.
       type: 'array',
       arrayElementsValidator: {
         type: 'object',
         required: true,
         propertyValidators: {
+          // The name of the feature toggle, as used within applications.
           name: {
             type: 'string',
             required: true,
             mustNotBeEmpty: true,
             regexPattern: featureToggleNameRegex
           },
+          // A description of the feature toggle for documentation within the feature toggle manager.
           description: {
             type: 'string',
             required: true,
             mustNotBeEmpty: true
           },
+          // The ticket id related to the feature toggle, for example KBW-1234
           ticketId: {
-            // the ticket id related to the feature toggle, for example KBW-1234
             type: 'string'
           },
+          // The state of the feature toggle.
           state: {
             type: 'enum',
             predefinedValues: [ 'development', 'ready', 'remove' ],
             required: true
           },
+          // Any extra notes about the feature toggle
           note: {
-            // Any extra notes about the feature toggle
             type: 'string'
           }
         }

--- a/databases/app-config-sync/fragment-feature-release-toggle-definitions.js
+++ b/databases/app-config-sync/fragment-feature-release-toggle-definitions.js
@@ -1,42 +1,47 @@
-function() {
-  var typeRegexMatchGroups = featureToggleNameRegex.exec(doc._id);
-  var PROCESSOR_ID_MATCH_GROUP = 1;
-
-  return {
-    channels: {
-      view: [ 'view-feature-release-toggle-definitions', 'view-config' ],
-      add: [ 'edit-feature-release-toggle-definitions', 'edit-config' ],
-      replace: [ 'edit-feature-release-toggle-definitions', 'edit-config' ],
-      remove: [ 'remove-feature-release-toggle-definitions', 'remove-config' ]
-    },
-    typeFilter: function(doc, oldDoc) {
-      // Example valid document IDs: "feature-release-toggle.foo-toggle", "feature-release-toggle.bar_1"
-      return new RegExp('^feature-release-toggle\.' + featureToggleNamePattern + '$').test(doc._id);
-    },
-    propertyValidators: {
-      name: {
-        type: 'string',
+{
+  channels: {
+    view: [ 'view-feature-release-toggle-definitions', 'view-config' ],
+    add: [ 'edit-feature-release-toggle-definitions', 'edit-config' ],
+    replace: [ 'edit-feature-release-toggle-definitions', 'edit-config' ],
+    remove: [ 'remove-feature-release-toggle-definitions', 'remove-config' ]
+  },
+  typeFilter: function(doc, oldDoc) {
+    return doc._id === 'featureReleaseToggleDefinitions';
+  },
+  propertyValidators: {
+    toggles: {
+      // A list of actions that are available to the recipient of the notification
+      type: 'array',
+      arrayElementsValidator: {
+        type: 'object',
         required: true,
-        mustNotBeEmpty: true,
-        immutable: true,
-        regexPattern: featureToggleNameRegex
-      },
-      description: {
-        type: 'string',
-        required: true,
-        mustNotBeEmpty: true
-      },
-      ticketId: {
-        type: 'string'
-      },
-      state: {
-        type: 'enum',
-        predefinedValues: [ 'development', 'ready', 'remove' ],
-        required: true
-      },
-      note: {
-        type: 'string'
+        propertyValidators: {
+          name: {
+            type: 'string',
+            required: true,
+            mustNotBeEmpty: true,
+            regexPattern: featureToggleNameRegex
+          },
+          description: {
+            type: 'string',
+            required: true,
+            mustNotBeEmpty: true
+          },
+          ticketId: {
+            // the ticket id related to the feature toggle, for example KBW-1234
+            type: 'string'
+          },
+          state: {
+            type: 'enum',
+            predefinedValues: [ 'development', 'ready', 'remove' ],
+            required: true
+          },
+          note: {
+            // Any extra notes about the feature toggle
+            type: 'string'
+          }
+        }
       }
     }
-  };
+  }
 }

--- a/test/app-config-sync-feature-release-toggle-definitions-spec.js
+++ b/test/app-config-sync-feature-release-toggle-definitions-spec.js
@@ -10,12 +10,20 @@ describe('app-config-sync feature release toggle definitions documents definitio
 
   it('saves feature release toggle definitions', function() {
     var doc = {
-      _id: 'feature-release-toggle.foo-toggle',
-      name: 'foo-toggle',
-      description: 'desc',
-      ticketId: 'kbw-2342',
-      state: 'development',
-      note: 'foo'
+      _id: 'featureReleaseToggleDefinitions',
+      toggles: [ {
+          name: 'foo-toggle',
+          description: 'desc',
+          ticketId: 'kbw-2342',
+          state: 'development',
+          note: 'foo'
+        }, {
+          name: 'bar-toggle',
+          description: 'desc',
+          ticketId: 'kbw-141',
+          state: 'development',
+        }
+      ]
     };
 
     testHelper.verifyDocumentCreated(doc, expectedChannels);
@@ -23,43 +31,21 @@ describe('app-config-sync feature release toggle definitions documents definitio
 
   it('refuses a document with invalid content', function() {
     var invalidDoc = {
-      _id: 'feature-release-toggle.foo-toggle',
-      name: '',
-      state: 'foo'
+      _id: 'featureReleaseToggleDefinitions',
+      toggles: [ {
+          foo: 'bar'
+        }
+      ]
     };
 
     testHelper.verifyDocumentNotCreated(
       invalidDoc,
       'featureReleaseToggleDefinitions',
       [
-        errorFormatter.mustNotBeEmptyViolation('name'),
-        errorFormatter.regexPatternItemViolation('name', /^[a-z0-9_-]+$/),
-        errorFormatter.requiredValueViolation('description'),
-        errorFormatter.enumPredefinedValueViolation('state', [ 'development', 'ready', 'remove' ])
-      ],
-      expectedChannels);
-  });
-
-  it('cannot replace name property', function() {
-    var doc = {
-      _id: 'feature-release-toggle.foo-toggle',
-      name: 'foo-toggle-2',
-      description: 'desc',
-      state: 'development'
-    };
-    var oldDoc = {
-      _id: 'feature-release-toggle.foo-toggle',
-      name: 'foo-toggle',
-      description: 'desc',
-      state: 'development'
-    };
-
-    testHelper.verifyDocumentRejected(
-      doc,
-      oldDoc,
-      'featureReleaseToggleDefinitions',
-      [
-        errorFormatter.immutableItemViolation('name')
+        errorFormatter.requiredValueViolation('toggles[0].name'),
+        errorFormatter.requiredValueViolation('toggles[0].description'),
+        errorFormatter.requiredValueViolation('toggles[0].state'),
+        errorFormatter.unsupportedProperty('toggles[0].foo')
       ],
       expectedChannels);
   });


### PR DESCRIPTION
I ran into the issue of wanting to query all available feature toggles, which couldnt be done simply with the rest api. This change makes this easier by making toggle definitions a single document that contains an array of definitions.