### PR TITLE
CWAP-245: Update the shoebox channel access definitions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build
 /.idea
 npm-debug.log
+/*.iml

--- a/databases/business-sync/fragment-shoebox-item.js
+++ b/databases/business-sync/fragment-shoebox-item.js
@@ -1,5 +1,5 @@
 {
-  channels: getDocSyncChannels(doc, oldDoc),
+  channels: getDocSyncChannels(doc, oldDoc, 'SHOEBOX_ITEMS'),
   typeFilter: function(doc, oldDoc) {
     // Keyspace schema:  biz.<biz_id>.shoeboxItem.<item_type>.<uuid>
     return createBusinessEntityRegex('shoeboxItem\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+').test(doc._id);

--- a/test/business-sync-shoebox-item-spec.js
+++ b/test/business-sync-shoebox-item-spec.js
@@ -8,7 +8,7 @@ describe('business-sync shoebox item document definition', function() {
   });
 
   var expectedDocType = 'shoeboxItem';
-  var staffPrivilege = 'STAFF';
+  var expectedBasePrivilege = 'SHOEBOX_ITEMS';
 
   it('successfully creates a valid shoebox item document', function() {
     var doc = {
@@ -21,7 +21,7 @@ describe('business-sync shoebox item document definition', function() {
       unknownProp: 'some-value'
     };
 
-    testHelper.verifyDocumentCreated(doc, [ staffPrivilege ]);
+    businessSyncSpecHelper.verifyDocumentCreated(expectedBasePrivilege, 3, doc);
   });
 
   it('cannot create a shoebox item document when the properties are invalid', function() {
@@ -34,7 +34,9 @@ describe('business-sync shoebox item document definition', function() {
       data: 2.4,
     };
 
-    testHelper.verifyDocumentNotCreated(
+    businessSyncSpecHelper.verifyDocumentNotCreated(
+      expectedBasePrivilege,
+      1,
       doc,
       expectedDocType,
       [
@@ -43,8 +45,7 @@ describe('business-sync shoebox item document definition', function() {
         errorFormatter.typeConstraintViolation('sourceId', 'string'),
         errorFormatter.datetimeFormatInvalid('received'),
         errorFormatter.typeConstraintViolation('data', 'string'),
-      ],
-      [ staffPrivilege ]);
+      ]);
   });
 
   it('cannot replace a valid shoebox item document', function() {
@@ -65,7 +66,7 @@ describe('business-sync shoebox item document definition', function() {
       unknownProp: 'some-value'
     };
 
-    testHelper.verifyDocumentNotReplaced(doc, oldDoc, expectedDocType, [ errorFormatter.immutableDocViolation() ], [ staffPrivilege ]);
+    businessSyncSpecHelper.verifyDocumentNotReplaced(expectedBasePrivilege, 3, doc, oldDoc, expectedDocType, [ errorFormatter.immutableDocViolation() ]);
   });
 
   it('cannot delete a shoebox item document', function() {
@@ -78,6 +79,6 @@ describe('business-sync shoebox item document definition', function() {
       unknownProp: 'some-value'
     };
 
-    testHelper.verifyDocumentNotDeleted(oldDoc, expectedDocType, [ errorFormatter.immutableDocViolation() ], [ staffPrivilege ]);
+    businessSyncSpecHelper.verifyDocumentNotDeleted(expectedBasePrivilege, 3, oldDoc, expectedDocType, [ errorFormatter.immutableDocViolation() ]);
   });
 });

--- a/test/modules/business-sync-spec-helper.js
+++ b/test/modules/business-sync-spec-helper.js
@@ -32,3 +32,11 @@ exports.verifyDocumentNotReplaced = function(basePrivilegeName, businessId, doc,
     expectedErrorMessages,
     [ staffChannel, businessId + '-CHANGE_' + basePrivilegeName ]);
 };
+
+exports.verifyDocumentNotDeleted = function(basePrivilegeName, businessId, doc, expectedDocType, expectedErrorMessages) {
+  testHelper.verifyDocumentNotDeleted(
+    doc,
+    expectedDocType,
+    expectedErrorMessages,
+    [ staffChannel, businessId + '-REMOVE_' + basePrivilegeName ]);
+};


### PR DESCRIPTION
Give users access to their own shoebox data. This gives add, change, remove, and view privileges. They will need some/most/all of these to manage their data from the shoebox ui. I'm not really sure yet which of these, we'll flesh it out as we build up the app.