### PR TITLE
Upgrade to synctos 1.10.0

### DIFF
--- a/databases/business-sync/fragment-payment-processor-settlement.js
+++ b/databases/business-sync/fragment-payment-processor-settlement.js
@@ -41,11 +41,8 @@ function() {
         required: true,
         mustNotBeEmpty: true,
         immutable: true,
-        regexPattern: function(doc, oldDoc, value, oldValue) {
-          var expectedSettlementId = typeRegexMatchGroups[SETTLEMENT_ID_MATCH_GROUP];
-
-          // Note that this regex uses double quotes rather than single quotes as a workaround to https://github.com/Kashoo/synctos/issues/116
-          return new RegExp("^" + expectedSettlementId + "$");
+        mustEqual: function(doc, oldDoc, value, oldValue) {
+          return typeRegexMatchGroups[SETTLEMENT_ID_MATCH_GROUP];
         }
       },
       processorId: {
@@ -54,11 +51,8 @@ function() {
         required: true,
         mustNotBeEmpty: true,
         immutable: true,
-        regexPattern: function(doc, oldDoc, value, oldValue) {
-          var expectedProcessorId = typeRegexMatchGroups[PROCESSOR_ID_MATCH_GROUP];
-
-          // Note that this regex uses double quotes rather than single quotes as a workaround to https://github.com/Kashoo/synctos/issues/116
-          return new RegExp("^" + expectedProcessorId + "$");
+        mustEqual: function(doc, oldDoc, value, oldValue) {
+          return typeRegexMatchGroups[PROCESSOR_ID_MATCH_GROUP];
         }
       },
       capturedAt: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,12 +151,6 @@
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
-    "expect.js": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz",
-      "integrity": "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s=",
-      "dev": true
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -207,11 +201,6 @@
         "entities": "1.0.0",
         "readable-stream": "1.1.14"
       }
-    },
-    "indent.js": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/indent.js/-/indent.js-0.1.5.tgz",
-      "integrity": "sha1-HLMntxOFuc5vJJjJfzv4NCffw7o="
     },
     "inflight": {
       "version": "1.0.6",
@@ -338,12 +327,6 @@
       "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
       "dev": true
     },
-    "simple-mock": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/simple-mock/-/simple-mock-0.8.0.tgz",
-      "integrity": "sha1-ScmiI/pu6o4sT9aUj+gwDNillPM=",
-      "dev": true
-    },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -366,12 +349,9 @@
       }
     },
     "synctos": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/synctos/-/synctos-1.9.1.tgz",
-      "integrity": "sha1-MMfMfkA/6UPHpqet/qLESwuyOvg=",
-      "requires": {
-        "indent.js": "0.1.5"
-      }
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/synctos/-/synctos-1.10.0.tgz",
+      "integrity": "sha512-YK9Yyj8FCBZRuqGCWfX7T40ACEmPdb1MrjZDU5v0m5F38HkQACAR25NAkzUjdf+H7qY2+uNl956Wg62l1QGxiQ=="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -2,13 +2,11 @@
   "name": "kashoo-document-definitions",
   "version": "1.0.0",
   "dependencies": {
-    "synctos": "^1.9.1"
+    "synctos": "^1.10.0"
   },
   "devDependencies": {
-    "expect.js": "^0.3.1",
     "jshint": "^2.9.4",
-    "mocha": "^5.0.0",
-    "simple-mock": "^0.8.0"
+    "mocha": "^5.0.0"
   },
   "scripts": {
     "test": "etc/prepare-tests.sh && node_modules/.bin/mocha",

--- a/test/app-config-sync-feature-release-toggle-definitions-spec.js
+++ b/test/app-config-sync-feature-release-toggle-definitions-spec.js
@@ -1,9 +1,9 @@
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('app-config-sync feature release toggle definitions documents definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/app-config-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/app-config-sync/sync-function.js');
   });
 
   var expectedChannels = [ 'edit-feature-release-toggle-definitions', 'edit-config' ];

--- a/test/app-config-sync-feature-release-toggles-spec.js
+++ b/test/app-config-sync-feature-release-toggles-spec.js
@@ -1,9 +1,9 @@
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('app-config-sync feature release toggle document definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/app-config-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/app-config-sync/sync-function.js');
   });
 
   var expectedChannels = [ 'edit-feature-release-toggles', 'edit-config' ];

--- a/test/app-config-sync-payment-notifications-spec.js
+++ b/test/app-config-sync-payment-notifications-spec.js
@@ -1,9 +1,9 @@
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('app-config-sync payment notification templates document definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/app-config-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/app-config-sync/sync-function.js');
   });
 
   var expectedChannels = [ 'edit-config' ];

--- a/test/app-config-sync-payment-processing-fee-spec.js
+++ b/test/app-config-sync-payment-processing-fee-spec.js
@@ -1,9 +1,9 @@
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('app-config-sync payment processing fee template document definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/app-config-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/app-config-sync/sync-function.js');
   });
 
   var expectedChannels = [ 'edit-config' ];

--- a/test/app-config-sync-settlement-notifications-spec.js
+++ b/test/app-config-sync-settlement-notifications-spec.js
@@ -1,9 +1,9 @@
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('app-config-sync settlement notification templates document definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/app-config-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/app-config-sync/sync-function.js');
   });
 
   var expectedChannels = [ 'edit-config' ];

--- a/test/app-config-sync-wepay-registration-confirmation-spec.js
+++ b/test/app-config-sync-wepay-registration-confirmation-spec.js
@@ -1,9 +1,9 @@
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('app-config-sync WePay registration confirmation template document definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/app-config-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/app-config-sync/sync-function.js');
   });
 
   var expectedChannels = [ 'edit-config' ];

--- a/test/busines-sync-square-data-spec.js
+++ b/test/busines-sync-square-data-spec.js
@@ -1,4 +1,4 @@
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 var staffChannel = 'STAFF';
@@ -6,7 +6,7 @@ var documentType = 'squareData';
 
 describe('business-sync square data entity: ', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/business-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/business-sync/sync-function.js');
   });
 
   /* Generic function for doing a set of common tests against a given document type */

--- a/test/business-sync-business-config-spec.js
+++ b/test/business-sync-business-config-spec.js
@@ -1,10 +1,10 @@
 var businessSyncSpecHelper = require('./modules/business-sync-spec-helper.js');
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('business-sync business configuration document definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/business-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/business-sync/sync-function.js');
   });
 
   function verifyBusinessConfigCreated(businessId, doc) {
@@ -100,8 +100,8 @@ describe('business-sync business configuration document definition', function() 
       doc,
       oldDoc,
       [
-        errorFormatter.supportedExtensionsAttachmentViolation('businessLogoAttachment', [ 'png', 'gif', 'jpg', 'jpeg' ]),
-        errorFormatter.supportedContentTypesAttachmentViolation('businessLogoAttachment', [ 'image/png', 'image/gif', 'image/jpeg' ]),
+        errorFormatter.supportedExtensionsAttachmentReferenceViolation('businessLogoAttachment', [ 'png', 'gif', 'jpg', 'jpeg' ]),
+        errorFormatter.supportedContentTypesAttachmentReferenceViolation('businessLogoAttachment', [ 'image/png', 'image/gif', 'image/jpeg' ]),
         errorFormatter.maximumSizeAttachmentViolation('businessLogoAttachment', 2097152),
         errorFormatter.maximumIndividualAttachmentSizeViolation('invalid.xml', 102400),
         errorFormatter.maximumAttachmentCountViolation(1),

--- a/test/business-sync-merchant-accounts-reference-spec.js
+++ b/test/business-sync-merchant-accounts-reference-spec.js
@@ -1,10 +1,10 @@
 var businessSyncSpecHelper = require('./modules/business-sync-spec-helper.js');
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('business-sync merchant accounts reference document definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/business-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/business-sync/sync-function.js');
   });
 
   var expectedDocType = 'merchantAccountsReference';

--- a/test/business-sync-notification-spec.js
+++ b/test/business-sync-notification-spec.js
@@ -1,10 +1,10 @@
 var businessSyncSpecHelper = require('./modules/business-sync-spec-helper.js');
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('business-sync notification document definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/business-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/business-sync/sync-function.js');
   });
 
   var expectedDocType = 'notification';

--- a/test/business-sync-notification-transport-processing-summary-spec.js
+++ b/test/business-sync-notification-transport-processing-summary-spec.js
@@ -1,10 +1,10 @@
 var businessSyncSpecHelper = require('./modules/business-sync-spec-helper.js');
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('business-sync notification transport processing summary document definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/business-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/business-sync/sync-function.js');
   });
 
   function verifyProcessingSummaryWritten(doc, oldDoc) {

--- a/test/business-sync-notification-transport-spec.js
+++ b/test/business-sync-notification-transport-spec.js
@@ -1,10 +1,10 @@
 var businessSyncSpecHelper = require('./modules/business-sync-spec-helper.js');
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('business-sync notification transport document definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/business-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/business-sync/sync-function.js');
   });
 
   var expectedDocType = 'notificationTransport';

--- a/test/business-sync-notifications-config-spec.js
+++ b/test/business-sync-notifications-config-spec.js
@@ -1,10 +1,10 @@
 var businessSyncSpecHelper = require('./modules/business-sync-spec-helper.js');
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('business-sync notifications configuration document definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/business-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/business-sync/sync-function.js');
   });
 
   var expectedDocType = 'notificationsConfig';

--- a/test/business-sync-notifications-reference-spec.js
+++ b/test/business-sync-notifications-reference-spec.js
@@ -1,10 +1,10 @@
 var businessSyncSpecHelper = require('./modules/business-sync-spec-helper.js');
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('business-sync notifications reference document definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/business-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/business-sync/sync-function.js');
   });
 
   var expectedDocType = 'notificationsReference';

--- a/test/business-sync-payment-attempt-spec.js
+++ b/test/business-sync-payment-attempt-spec.js
@@ -1,10 +1,10 @@
 var businessSyncSpecHelper = require('./modules/business-sync-spec-helper.js');
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('business-sync payment processing attempt document definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/business-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/business-sync/sync-function.js');
   });
 
   function verifyPaymentAttemptWritten(businessId, doc, oldDoc) {

--- a/test/business-sync-payment-processor-business-default-spec.js
+++ b/test/business-sync-payment-processor-business-default-spec.js
@@ -1,10 +1,10 @@
 var businessSyncSpecHelper = require('./modules/business-sync-spec-helper.js');
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('business-sync payment processor business default document definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/business-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/business-sync/sync-function.js');
   });
 
   var expectedDocType = 'paymentProcessorBusinessDefault';

--- a/test/business-sync-payment-processor-customer-default-spec.js
+++ b/test/business-sync-payment-processor-customer-default-spec.js
@@ -1,10 +1,10 @@
 var businessSyncSpecHelper = require('./modules/business-sync-spec-helper.js');
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('business-sync payment processor customer default document definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/business-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/business-sync/sync-function.js');
   });
 
   var expectedDocType = 'paymentProcessorCustomerDefault';

--- a/test/business-sync-payment-processor-definition-spec.js
+++ b/test/business-sync-payment-processor-definition-spec.js
@@ -1,10 +1,10 @@
 var businessSyncSpecHelper = require('./modules/business-sync-spec-helper.js');
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('business-sync payment processor definition document definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/business-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/business-sync/sync-function.js');
   });
 
   var expectedDocType = 'paymentProcessorDefinition';

--- a/test/business-sync-payment-processor-settlement-spec.js
+++ b/test/business-sync-payment-processor-settlement-spec.js
@@ -1,10 +1,10 @@
 var businessSyncSpecHelper = require('./modules/business-sync-spec-helper.js');
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('business-sync payment processor settlement document definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/business-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/business-sync/sync-function.js');
   });
 
   function verifySettlementWritten(businessId, doc, oldDoc) {
@@ -52,8 +52,8 @@ describe('business-sync payment processor settlement document definition', funct
       [
         errorFormatter.maximumValueViolation('businessId', 12345),
         errorFormatter.requiredValueViolation('transferId'),
-        errorFormatter.regexPatternItemViolation('processorId', /^XYZ$/),
-        errorFormatter.regexPatternItemViolation('settlementId', /^foo-bar$/),
+        errorFormatter.mustEqualViolation('processorId', 'XYZ'),
+        errorFormatter.mustEqualViolation('settlementId', 'foo-bar'),
         errorFormatter.datetimeFormatInvalid('capturedAt'),
         errorFormatter.typeConstraintViolation('processedAt', 'datetime'),
         errorFormatter.requiredValueViolation('amount')

--- a/test/business-sync-payment-requisition-spec.js
+++ b/test/business-sync-payment-requisition-spec.js
@@ -1,10 +1,10 @@
 var businessSyncSpecHelper = require('./modules/business-sync-spec-helper.js');
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('business-sync payment requisition document definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/business-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/business-sync/sync-function.js');
   });
 
   var expectedDocType = 'paymentRequisition';

--- a/test/business-sync-payment-requisitions-reference-spec.js
+++ b/test/business-sync-payment-requisitions-reference-spec.js
@@ -1,10 +1,10 @@
 var businessSyncSpecHelper = require('./modules/business-sync-spec-helper.js');
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('business-sync payment requisitions reference document definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/business-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/business-sync/sync-function.js');
   });
 
   var expectedDocType = 'paymentRequisitionsReference';

--- a/test/business-sync-shoebox-item-spec.js
+++ b/test/business-sync-shoebox-item-spec.js
@@ -1,10 +1,10 @@
 var businessSyncSpecHelper = require('./modules/business-sync-spec-helper.js');
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 describe('business-sync shoebox item document definition', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/business-sync/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/business-sync/sync-function.js');
   });
 
   var expectedDocType = 'shoeboxItem';

--- a/test/modules/business-sync-spec-helper.js
+++ b/test/modules/business-sync-spec-helper.js
@@ -1,6 +1,6 @@
 // This module contains a collection of functions to be used when validating the business-sync document definitions
 
-var testHelper = require('../../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 
 var staffChannel = exports.staffChannel = 'STAFF';
 

--- a/test/square-data-spec.js
+++ b/test/square-data-spec.js
@@ -1,11 +1,11 @@
-var testHelper = require('../node_modules/synctos/etc/test-helper.js');
+var testHelper = require('synctos').testHelper;
 var errorFormatter = testHelper.validationErrorFormatter;
 
 var staffChannel = 'STAFF';
 
 describe('square-data database:', function() {
   beforeEach(function() {
-    testHelper.init('build/sync-functions/square-data/sync-function.js');
+    testHelper.initSyncFunction('build/sync-functions/square-data/sync-function.js');
   });
 
   /* Generic function for doing a set of common tests against a given document type */


### PR DESCRIPTION
In addition to upgrading to synctos v1.10.0, I also took the liberty of removing unused development dependencies, switching away from the deprecated versions of the test-helper and validation-error-message-formatter modules and introducing a couple of `mustEqual` constraints where `regexPattern` was once used as a stopgap.