### PR TITLE
Upgrade to synctos 2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -349,9 +349,9 @@
       }
     },
     "synctos": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/synctos/-/synctos-2.2.1.tgz",
-      "integrity": "sha512-j6RU8JZ8tsqMWJOp87hjuBmY9qV22XaJ5xMiK7ONd0CyeTcDTwK1gO0YoLC6jiJGPSJtUx72Rg5iNzI2naZNSQ=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/synctos/-/synctos-2.3.0.tgz",
+      "integrity": "sha512-5Nnn8FrRrtOXVOA6avyt18527r/5TenC6tgYxvEmaX/Y7Gz8v2M8T0xd1YbVP4PmnR3ZiNesih940oHr1+68KQ=="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
@@ -21,9 +21,9 @@
       }
     },
     "browser-stdout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
     "cli": {
@@ -79,9 +79,9 @@
       }
     },
     "diff": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "dom-serializer": {
@@ -225,9 +225,9 @@
       "dev": true
     },
     "jshint": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.4.tgz",
-      "integrity": "sha1-XjupeEjVKQJz21FK7kf+JM9ZKTQ=",
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
+      "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
       "dev": true,
       "requires": {
         "cli": "1.0.1",
@@ -252,7 +252,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -271,15 +271,15 @@
       }
     },
     "mocha": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.0.tgz",
-      "integrity": "sha512-ukB2dF+u4aeJjc6IGtPNnJXfeby5d4ZqySlIBT0OEyva/DrMjVm5HkQxKnHDLKEfEQBsEnwTg9HHhtPHJdTd8w==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.5.tgz",
+      "integrity": "sha512-3MM3UjZ5p8EJrYpG7s+29HAI9G7sTzKEe4+w37Dg0QP7qL4XGsV+Q2xet2cE37AqdgN1OtYQB6Vl98YiPV3PgA==",
       "dev": true,
       "requires": {
-        "browser-stdout": "1.3.0",
+        "browser-stdout": "1.3.1",
         "commander": "2.11.0",
         "debug": "3.1.0",
-        "diff": "3.3.1",
+        "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.2",
         "growl": "1.10.3",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "synctos": "^2.3.0"
   },
   "devDependencies": {
-    "jshint": "^2.9.4",
-    "mocha": "^5.0.0"
+    "jshint": "^2.9.5",
+    "mocha": "^5.0.5"
   },
   "scripts": {
     "test": "etc/prepare-tests.sh && node_modules/.bin/mocha",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kashoo-document-definitions",
   "version": "1.0.0",
   "dependencies": {
-    "synctos": "^2.2.1"
+    "synctos": "^2.3.0"
   },
   "devDependencies": {
     "jshint": "^2.9.4",

--- a/test/app-config-sync-feature-release-toggle-definitions-spec.js
+++ b/test/app-config-sync-feature-release-toggle-definitions-spec.js
@@ -3,10 +3,10 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('app-config-sync feature release toggle definitions documents definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/app-config-sync/sync-function.js');
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/app-config-sync/sync-function.js');
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   var expectedChannels = [ 'edit-feature-release-toggle-definitions', 'edit-config' ];

--- a/test/app-config-sync-feature-release-toggles-spec.js
+++ b/test/app-config-sync-feature-release-toggles-spec.js
@@ -3,10 +3,10 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('app-config-sync feature release toggle document definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/app-config-sync/sync-function.js');
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/app-config-sync/sync-function.js');
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   var expectedChannels = [ 'edit-feature-release-toggles', 'edit-config' ];

--- a/test/app-config-sync-payment-notifications-spec.js
+++ b/test/app-config-sync-payment-notifications-spec.js
@@ -3,10 +3,10 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('app-config-sync payment notification templates document definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/app-config-sync/sync-function.js');
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/app-config-sync/sync-function.js');
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   var expectedChannels = [ 'edit-config' ];

--- a/test/app-config-sync-payment-processing-fee-spec.js
+++ b/test/app-config-sync-payment-processing-fee-spec.js
@@ -3,10 +3,10 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('app-config-sync payment processing fee template document definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/app-config-sync/sync-function.js');
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/app-config-sync/sync-function.js');
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   var expectedChannels = [ 'edit-config' ];

--- a/test/app-config-sync-settlement-notifications-spec.js
+++ b/test/app-config-sync-settlement-notifications-spec.js
@@ -3,10 +3,10 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('app-config-sync settlement notification templates document definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/app-config-sync/sync-function.js');
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/app-config-sync/sync-function.js');
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   var expectedChannels = [ 'edit-config' ];

--- a/test/app-config-sync-wepay-registration-confirmation-spec.js
+++ b/test/app-config-sync-wepay-registration-confirmation-spec.js
@@ -3,10 +3,10 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('app-config-sync WePay registration confirmation template document definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/app-config-sync/sync-function.js');
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/app-config-sync/sync-function.js');
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   var expectedChannels = [ 'edit-config' ];

--- a/test/business-sync-business-config-spec.js
+++ b/test/business-sync-business-config-spec.js
@@ -4,11 +4,11 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('business-sync business configuration document definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
+  var businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
-    businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   function verifyBusinessConfigCreated(businessId, doc) {

--- a/test/business-sync-merchant-accounts-reference-spec.js
+++ b/test/business-sync-merchant-accounts-reference-spec.js
@@ -4,11 +4,11 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('business-sync merchant accounts reference document definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
+  var businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
-    businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   var expectedDocType = 'merchantAccountsReference';
@@ -23,7 +23,7 @@ describe('business-sync merchant accounts reference document definition', functi
           merchantAccountId: 'my-merchant-account1',
           authorization: 'my-access-token1',
           paymentProcessorDefinitionId: 'my-payment-processor1',
-          registrationConfirmed: '2017-02-17T18:44:35.128-0800'
+          registrationConfirmed: '2017-02-17T18:44:35.128-08:00'
         },
         account2: {
           provider: 'bar',
@@ -31,7 +31,7 @@ describe('business-sync merchant accounts reference document definition', functi
           authorization: 'my-access-token2',
           paymentProcessorDefinitionId: 'my-payment-processor2',
           registrationConfirmationRequisitions: [
-            '2017-02-16T07:15:32.767-0800'
+            '2017-02-16T07:15:32.767-08:00'
           ]
         }
       }

--- a/test/business-sync-notification-spec.js
+++ b/test/business-sync-notification-spec.js
@@ -4,11 +4,11 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('business-sync notification document definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
+  var businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
-    businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   var expectedDocType = 'notification';

--- a/test/business-sync-notification-transport-processing-summary-spec.js
+++ b/test/business-sync-notification-transport-processing-summary-spec.js
@@ -4,11 +4,11 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('business-sync notification transport processing summary document definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
+  var businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
-    businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   function verifyProcessingSummaryWritten(doc, oldDoc) {

--- a/test/business-sync-notification-transport-spec.js
+++ b/test/business-sync-notification-transport-spec.js
@@ -4,11 +4,11 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('business-sync notification transport document definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
+  var businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
-    businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   var expectedDocType = 'notificationTransport';

--- a/test/business-sync-notifications-config-spec.js
+++ b/test/business-sync-notifications-config-spec.js
@@ -4,11 +4,11 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('business-sync notifications configuration document definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
+  var businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
-    businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   var expectedDocType = 'notificationsConfig';

--- a/test/business-sync-notifications-reference-spec.js
+++ b/test/business-sync-notifications-reference-spec.js
@@ -4,11 +4,11 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('business-sync notifications reference document definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
+  var businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
-    businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   var expectedDocType = 'notificationsReference';

--- a/test/business-sync-payment-attempt-spec.js
+++ b/test/business-sync-payment-attempt-spec.js
@@ -4,11 +4,11 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('business-sync payment processing attempt document definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
+  var businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
-    businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   function verifyPaymentAttemptWritten(businessId, doc, oldDoc) {

--- a/test/business-sync-payment-processor-business-default-spec.js
+++ b/test/business-sync-payment-processor-business-default-spec.js
@@ -4,11 +4,11 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('business-sync payment processor business default document definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
+  var businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
-    businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   var expectedDocType = 'paymentProcessorBusinessDefault';

--- a/test/business-sync-payment-processor-customer-default-spec.js
+++ b/test/business-sync-payment-processor-customer-default-spec.js
@@ -4,11 +4,11 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('business-sync payment processor customer default document definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
+  var businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
-    businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   var expectedDocType = 'paymentProcessorCustomerDefault';

--- a/test/business-sync-payment-processor-definition-spec.js
+++ b/test/business-sync-payment-processor-definition-spec.js
@@ -4,11 +4,11 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('business-sync payment processor definition document definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
+  var businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
-    businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   var expectedDocType = 'paymentProcessorDefinition';

--- a/test/business-sync-payment-processor-settlement-spec.js
+++ b/test/business-sync-payment-processor-settlement-spec.js
@@ -4,11 +4,11 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('business-sync payment processor settlement document definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
+  var businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
-    businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   function verifySettlementWritten(businessId, doc, oldDoc) {

--- a/test/business-sync-payment-requisition-spec.js
+++ b/test/business-sync-payment-requisition-spec.js
@@ -4,11 +4,11 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('business-sync payment requisition document definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
+  var businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
-    businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   var expectedDocType = 'paymentRequisition';

--- a/test/business-sync-payment-requisitions-reference-spec.js
+++ b/test/business-sync-payment-requisitions-reference-spec.js
@@ -4,11 +4,11 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('business-sync payment requisitions reference document definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
+  var businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
-    businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   var expectedDocType = 'paymentRequisitionsReference';

--- a/test/business-sync-shoebox-item-spec.js
+++ b/test/business-sync-shoebox-item-spec.js
@@ -4,11 +4,11 @@ var testFixtureMaker = synctos.testFixtureMaker;
 var errorFormatter = synctos.validationErrorFormatter;
 
 describe('business-sync shoebox item document definition', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
+  var businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
-    businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   var expectedDocType = 'shoeboxItem';

--- a/test/business-sync-square-data-spec.js
+++ b/test/business-sync-square-data-spec.js
@@ -6,10 +6,10 @@ var staffChannel = 'STAFF';
 var documentType = 'squareData';
 
 describe('business-sync square data entity: ', function() {
-  var testFixture;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   /* Generic function for doing a set of common tests against a given document type */

--- a/test/square-data-spec.js
+++ b/test/square-data-spec.js
@@ -5,10 +5,10 @@ var errorFormatter = synctos.validationErrorFormatter;
 var staffChannel = 'STAFF';
 
 describe('square-data database:', function() {
-  var testFixture, businessSyncSpecHelper;
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/square-data/sync-function.js');
 
-  beforeEach(function() {
-    testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/square-data/sync-function.js');
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
   });
 
   /* Generic function for doing a set of common tests against a given document type */


### PR DESCRIPTION
Includes the following changes:

- Fixed the time zone format of dates in the test cases for the business-sync bucket's merchantAccountsReference document type
- Moved initialization of test fixture objects in test files to the point at which they are declared to enable intelligent autocomplete of the test fixture's members
- Upgraded development dependencies