### PR TITLE
CWAP-339 import rules

### DIFF
--- a/databases/business-sync/fragment-shoebox-import-rules.js
+++ b/databases/business-sync/fragment-shoebox-import-rules.js
@@ -65,6 +65,18 @@
               required: true,
               allowUnknownProperties: true,
               propertyValidators: function(doc, oldDoc, value, oldValue) {
+                var suggestedValueValidator = {
+                  type: value.suggestedField === 'accountNumber' ? 'string' : 'array',
+                  required: true,
+                  mustNotBeEmpty: true
+                };
+                if (value.suggestedField === 'taxIds') {
+                  suggestedValueValidator.arrayElementsValidator = {
+                    type: 'integer',
+                    mustNotBeEmpty: true,
+                    minimumValueExclusive: 0
+                  };
+                }
                 return {
                   // Name of the field the suggestion is intended for.  Field name should imply expected type.
                   suggestedField: {
@@ -73,10 +85,7 @@
                     required: true
                   },
                   // Value of the suggestion
-                  suggestedValue: {
-                    type: value.suggestedField === 'accountNumber' ? 'string' : 'array',
-                    required: true
-                  }
+                  suggestedValue: suggestedValueValidator
                 };
               }
             }

--- a/databases/business-sync/fragment-shoebox-import-rules.js
+++ b/databases/business-sync/fragment-shoebox-import-rules.js
@@ -25,26 +25,34 @@
             arrayElementsValidator: {
               type: 'object',
               required: true,
-              propertyValidators: {
-                comparison: {
-                  // Comparison operation.  This will be specific to the field (ie, comparison on the amount field will be numerical)
-                  type: 'enum',
-                  predefinedValues: [ 'contains' ],
-                  required: true
-                },
-                field: {
-                  // The field to inspect for comparison
-                  type: 'enum',
-                  predefinedValues: [ 'description' ],
-                  required: true
-                },
-                // the value to use in the comparison.
-                // Omits type which is implied by the field (ie, description field expects a string value to compare against)
-                value: {
-                  type: 'string', // synctos does not support ambiguous types, but the intended type can be inferred from the field
+              propertyValidators: function(doc, oldDoc, value, oldValue) {
+                // the value to use in the comparison.  Type is dependent on the comparison operator
+                var valueValidator = {
+                  type: value.comparison === 'contains' ? 'string' : 'array',
                   mustNotBeEmpty: true,
                   required: true
+                };
+                if (value.comparison === 'containsAll') {
+                  valueValidator.arrayElementsValidator = {
+                    type: 'string',
+                    mustNotBeEmpty: true
+                  };
                 }
+                return {
+                  comparison: {
+                    // Comparison operation.  This will be specific to the field (ie, comparison on the amount field will be numerical)
+                    type: 'enum',
+                    predefinedValues: [ 'contains', 'containsAll' ],
+                    required: true
+                  },
+                  field: {
+                    // The field to inspect for comparison
+                    type: 'enum',
+                    predefinedValues: [ 'description' ],
+                    required: true
+                  },
+                  value: valueValidator
+                };
               }
             }
           },
@@ -56,18 +64,20 @@
               type: 'object',
               required: true,
               allowUnknownProperties: true,
-              propertyValidators: {
-                // Name of the field the suggestion is intended for.  Field name should imply expected type.
-                suggestedField: {
-                  type: 'enum',
-                  predefinedValues: [ 'accountNumber', 'taxIds' ],
-                  required: true
-                }
-                // // Value of the suggestion
-                // suggestedValue: {
-                //   type: 'string', // synctos does not support ambiguous types, but the intended type can be inferred from the field
-                //   required: true
-                // }
+              propertyValidators: function(doc, oldDoc, value, oldValue) {
+                return {
+                  // Name of the field the suggestion is intended for.  Field name should imply expected type.
+                  suggestedField: {
+                    type: 'enum',
+                    predefinedValues: [ 'accountNumber', 'taxIds' ],
+                    required: true
+                  },
+                  // Value of the suggestion
+                  suggestedValue: {
+                    type: value.suggestedField === 'accountNumber' ? 'string' : 'array',
+                    required: true
+                  }
+                };
               }
             }
           },

--- a/test/business-sync-shoebox-rules-spec.js
+++ b/test/business-sync-shoebox-rules-spec.js
@@ -86,7 +86,9 @@ describe('business-sync shoebox import rules document definition', function() {
       doc,
       expectedDocType,
       [
-        errorFormatter.enumPredefinedValueViolation('rules[ABC].criteria[1].comparison', [ 'contains' ]),
+        errorFormatter.typeConstraintViolation('rules[ABC].criteria[1].value', 'array'),
+        errorFormatter.typeConstraintViolation('rules[ABC].suggestions[0].suggestedValue', 'array'),
+        errorFormatter.enumPredefinedValueViolation('rules[ABC].criteria[1].comparison', [ 'contains', 'containsAll' ]),
         errorFormatter.enumPredefinedValueViolation('rules[ABC].criteria[1].field', [ 'description' ]),
         errorFormatter.mustNotBeEmptyViolation('rules[ABC].criteria[1].value'),
         errorFormatter.enumPredefinedValueViolation('rules[ABC].suggestions[0].suggestedField', [ 'accountNumber', 'taxIds' ]),
@@ -194,7 +196,8 @@ describe('business-sync shoebox import rules document definition', function() {
       oldDoc,
       expectedDocType,
       [
-        errorFormatter.enumPredefinedValueViolation('rules[ABC].criteria[1].comparison', [ 'contains' ]),
+        errorFormatter.typeConstraintViolation('rules[ABC].criteria[1].value', 'array'),
+        errorFormatter.enumPredefinedValueViolation('rules[ABC].criteria[1].comparison', [ 'contains', 'containsAll' ]),
         errorFormatter.enumPredefinedValueViolation('rules[ABC].criteria[1].field', [ 'description' ]),
         errorFormatter.mustNotBeEmptyViolation('rules[ABC].criteria[1].value'),
         errorFormatter.requiredValueViolation('rules[ABC].suggestions'),

--- a/test/business-sync-shoebox-rules-spec.js
+++ b/test/business-sync-shoebox-rules-spec.js
@@ -24,6 +24,11 @@ describe('business-sync shoebox import rules document definition', function() {
               comparison: 'contains',
               field: 'description',
               value: 'this is garbage'
+            },
+            {
+              comparison: 'containsAll',
+              field: 'description',
+              value: [ 'part1', 'part2' ]
             }
           ],
           suggestions: [
@@ -59,6 +64,11 @@ describe('business-sync shoebox import rules document definition', function() {
               comparison: 'like',
               field: 'memo',
               value: ''
+            },
+            {
+              comparison: 'containsAll',
+              field: 'description',
+              value: ['', 'somethingToMatch']
             }
           ],
           suggestions: [
@@ -68,7 +78,11 @@ describe('business-sync shoebox import rules document definition', function() {
             },
             {
               suggestedField: 'taxIds',
-              suggestedValue: [333, 555]
+              suggestedValue: ['blargfh', 0]
+            },
+            {
+              suggestedField: 'taxIds',
+              suggestedValue: []
             }
           ],
         },
@@ -88,6 +102,10 @@ describe('business-sync shoebox import rules document definition', function() {
       [
         errorFormatter.typeConstraintViolation('rules[ABC].criteria[1].value', 'array'),
         errorFormatter.typeConstraintViolation('rules[ABC].suggestions[0].suggestedValue', 'array'),
+        errorFormatter.typeConstraintViolation('rules[ABC].suggestions[1].suggestedValue[0]', 'integer'),
+        errorFormatter.minimumValueExclusiveViolation('rules[ABC].suggestions[1].suggestedValue[1]', 0),
+        errorFormatter.mustNotBeEmptyViolation('rules[ABC].suggestions[2].suggestedValue'),
+        errorFormatter.mustNotBeEmptyViolation('rules[ABC].criteria[2].value[0]'),
         errorFormatter.enumPredefinedValueViolation('rules[ABC].criteria[1].comparison', [ 'contains', 'containsAll' ]),
         errorFormatter.enumPredefinedValueViolation('rules[ABC].criteria[1].field', [ 'description' ]),
         errorFormatter.mustNotBeEmptyViolation('rules[ABC].criteria[1].value'),


### PR DESCRIPTION
This PR imposes type specific validation on import rule properties, based on the values specified for `criteria[].comparison` and `suggestions[].suggestedValue`, including some specs to cover the new constraints