### PR TITLE
CWAP-442: Add accountTaxNumber field to the import rule definitions.

### DIFF
--- a/databases/business-sync/fragment-shoebox-import-rules.js
+++ b/databases/business-sync/fragment-shoebox-import-rules.js
@@ -112,8 +112,7 @@
                         return parentObj.suggestedField === 'accountTaxNumber';
                       },
                       validator: {
-                        type: 'integer',
-                        mustNotBeEmpty: true
+                        type: 'integer'
                       }
                     },
                     {

--- a/databases/business-sync/fragment-shoebox-import-rules.js
+++ b/databases/business-sync/fragment-shoebox-import-rules.js
@@ -86,7 +86,7 @@
                 // Name of the field the suggestion is intended for.  Field name should imply expected type.
                 suggestedField: {
                   type: 'enum',
-                  predefinedValues: [ 'accountNumber', 'taxIds' ],
+                  predefinedValues: [ 'accountNumber', 'accountTaxNumber', 'taxIds' ],
                   required: true
                 },
                 // Value of the suggestion
@@ -102,6 +102,17 @@
                       },
                       validator: {
                         type: 'string',
+                        mustNotBeEmpty: true
+                      }
+                    },
+                    {
+                      condition: function(doc, oldDoc, currentItemEntry, validationItemStack) {
+                        var parentObj = validationItemStack[validationItemStack.length - 1].itemValue;
+
+                        return parentObj.suggestedField === 'accountTaxNumber';
+                      },
+                      validator: {
+                        type: 'integer',
                         mustNotBeEmpty: true
                       }
                     },

--- a/test/business-sync-shoebox-rules-spec.js
+++ b/test/business-sync-shoebox-rules-spec.js
@@ -112,7 +112,7 @@ describe('business-sync shoebox import rules document definition', function() {
         errorFormatter.mustNotBeEmptyViolation('rules[ABC].criteria[2].value[0]'),
         errorFormatter.enumPredefinedValueViolation('rules[ABC].criteria[1].comparison', [ 'contains', 'containsAll' ]),
         errorFormatter.enumPredefinedValueViolation('rules[ABC].criteria[1].field', [ 'description' ]),
-        errorFormatter.enumPredefinedValueViolation('rules[ABC].suggestions[0].suggestedField', [ 'accountNumber', 'taxIds' ]),
+        errorFormatter.enumPredefinedValueViolation('rules[ABC].suggestions[0].suggestedField', [ 'accountNumber', 'accountTaxNumber', 'taxIds' ]),
         errorFormatter.hashtableKeyEmpty("rules"),
         errorFormatter.mustNotBeEmptyViolation('rules[].criteria'),
         errorFormatter.mustNotBeEmptyViolation('rules[].suggestions'),

--- a/test/business-sync-shoebox-rules-spec.js
+++ b/test/business-sync-shoebox-rules-spec.js
@@ -37,6 +37,10 @@ describe('business-sync shoebox import rules document definition', function() {
               suggestedValue: '2345'
             },
             {
+              suggestedField: 'accountTaxNumber',
+              suggestedValue: 12345,
+            },
+            {
               suggestedField: 'taxIds',
               suggestedValue: [333, 555]
             }


### PR DESCRIPTION
We're running ML and suggestions on the account tax number, which is an integer. Add support for this to the import rules (keep the old accountNumber around as well, at least for now).