### PR TITLE
CWAP-473: Allow deletion of shoebox items.

### DIFF
--- a/databases/business-sync/fragment-shoebox-item.js
+++ b/databases/business-sync/fragment-shoebox-item.js
@@ -5,7 +5,7 @@
     return createBusinessEntityRegex('shoeboxItem\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+').test(doc._id);
   },
   allowUnknownProperties: true,
-  cannotDelete: true,
+  cannotDelete: false,
   propertyValidators: {
     type: {
       // The type of shoebox item (bank transaction, uploaded document, email)

--- a/databases/business-sync/fragment-shoebox-item.js
+++ b/databases/business-sync/fragment-shoebox-item.js
@@ -5,7 +5,10 @@
     return createBusinessEntityRegex('shoeboxItem\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+').test(doc._id);
   },
   allowUnknownProperties: true,
-  cannotDelete: false,
+  cannotDelete: function(doc, oldDoc) {
+    // only document types can be deleted at the moment (because they are manually uploaded)
+    return oldDoc.type !== 'document';
+  },
   propertyValidators: {
     type: {
       // The type of shoebox item (bank transaction, uploaded document, email)

--- a/test/business-sync-shoebox-item-spec.js
+++ b/test/business-sync-shoebox-item-spec.js
@@ -357,7 +357,7 @@ describe('business-sync shoebox item document definition', function() {
     businessSyncSpecHelper.verifyDocumentNotReplaced(expectedBasePrivilege, 3, doc, oldDoc, expectedDocType, [ errorFormatter.immutableItemViolation('type'), errorFormatter.immutableItemViolation('source'), errorFormatter.immutableItemViolation('sourceId') ]);
   });
 
-  it('cannot delete a shoebox item document', function() {
+  it('can delete a shoebox item document', function() {
     var oldDoc = {
       _id: 'biz.3.shoeboxItem.bank-record.XYZ',
       type: 'bank',
@@ -369,6 +369,6 @@ describe('business-sync shoebox item document definition', function() {
       unknownProp: 'some-value'
     };
 
-    businessSyncSpecHelper.verifyDocumentNotDeleted(expectedBasePrivilege, 3, oldDoc, expectedDocType, [ errorFormatter.cannotDeleteDocViolation() ]);
+    businessSyncSpecHelper.verifyDocumentDeleted(expectedBasePrivilege, 3, oldDoc );
   });
 });

--- a/test/business-sync-shoebox-item-spec.js
+++ b/test/business-sync-shoebox-item-spec.js
@@ -357,7 +357,22 @@ describe('business-sync shoebox item document definition', function() {
     businessSyncSpecHelper.verifyDocumentNotReplaced(expectedBasePrivilege, 3, doc, oldDoc, expectedDocType, [ errorFormatter.immutableItemViolation('type'), errorFormatter.immutableItemViolation('source'), errorFormatter.immutableItemViolation('sourceId') ]);
   });
 
-  it('can delete a shoebox item document', function() {
+  it('can delete a document type shoebox item document', function() {
+    var oldDoc = {
+      _id: 'biz.3.shoeboxItem.bank-record.XYZ',
+      type: 'document',
+      source: 'yodlee',
+      received: '2016-06-18T18:57:35.328-08:00',
+      data: {
+        foo: 'bar'
+      },
+      unknownProp: 'some-value'
+    };
+
+    businessSyncSpecHelper.verifyDocumentDeleted(expectedBasePrivilege, 3, oldDoc );
+  });
+
+  it('cannot delete a bank type shoebox item document', function() {
     var oldDoc = {
       _id: 'biz.3.shoeboxItem.bank-record.XYZ',
       type: 'bank',
@@ -369,6 +384,6 @@ describe('business-sync shoebox item document definition', function() {
       unknownProp: 'some-value'
     };
 
-    businessSyncSpecHelper.verifyDocumentDeleted(expectedBasePrivilege, 3, oldDoc );
+    businessSyncSpecHelper.verifyDocumentNotDeleted(expectedBasePrivilege, 3, oldDoc, expectedDocType, [ errorFormatter.cannotDeleteDocViolation() ]);
   });
 });


### PR DESCRIPTION
We can delete shoebox items that aren't bank items. I don't think there is a way to enforce that constraint in synctos so this allows deletion of all items, and the ui will enforce that bank items are non-deletable.