### PR TITLE
Upgrade to synctos 2.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1003,9 +1003,9 @@
       }
     },
     "synctos": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/synctos/-/synctos-2.6.0.tgz",
-      "integrity": "sha512-wQPTNYjBvC8rnzJKO/aCEDnIXlDPU8OAge4c01A/GyXpLIuASPOJSI+7sBVeyrP43eAgM1RcMczIi74JDyB1aw=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/synctos/-/synctos-2.7.0.tgz",
+      "integrity": "sha512-zx+LWhgGx8Gou1ASHgsESYqGi1Y6hmAPanYurwiqFMayGb8Hs3PKXIoxxltEpMJYgmgLc3rq4Mfclgyv5MzomQ=="
     },
     "throttleit": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "kashoo-document-definitions",
   "version": "1.0.0",
   "dependencies": {
-    "synctos": "^2.6.0"
+    "synctos": "^2.7.0"
   },
   "devDependencies": {
     "jshint": "^2.9.6",


### PR DESCRIPTION
Includes support for the `requireAdmin` sync function API in synctos test fixtures. Should have no functional impact on `kashoo-document-definitions`.