### PR TITLE
CWAP-611:  New document definition for cacheing wepay auth tokens

### DIFF
--- a/databases/business-sync/doc-definitions.js
+++ b/databases/business-sync/doc-definitions.js
@@ -109,5 +109,8 @@ function() {
 
     // For storing Square data entities and any associations
     squareData: importDocumentDefinitionFragment('fragment-square-data.js'),
+
+    // For storing Wepay auth token
+    wepayAuthToken: importDocumentDefinitionFragment('fragment-wepay-auth-token.js'),
   };
 }

--- a/databases/business-sync/fragment-wepay-auth-token.js
+++ b/databases/business-sync/fragment-wepay-auth-token.js
@@ -1,0 +1,27 @@
+{
+  typeFilter: function(doc, oldDoc) {
+    return createBusinessEntityRegex('wepay\.[A-Za-z0-9_-]+\.auth$').test(doc._id);
+  },
+  channels: { write: staffChannel },
+  propertyValidators: {
+    user_id: {
+      type: 'integer',
+      required: true,
+      minimumValue: 1
+    },
+    access_token: {
+      type: 'string',
+      required: true,
+      mustNotBeEmpty: true
+    },
+    token_type: {
+      type: 'string',
+      required: false
+    },
+    expires_in: {
+      type: 'integer',
+      required: false,
+      minimumValue: 1
+    }
+  }
+}

--- a/test/business-sync-wepay-auth-token-spec.js
+++ b/test/business-sync-wepay-auth-token-spec.js
@@ -1,0 +1,36 @@
+var businessSyncSpecHelperMaker = require('./helpers/business-sync-spec-helper-maker.js');
+var synctos = require('synctos');
+var testFixtureMaker = synctos.testFixtureMaker;
+var errorFormatter = synctos.validationErrorFormatter;
+
+describe('business-sync wepay auth token document definition', function() {
+  var testFixture = testFixtureMaker.initFromSyncFunction('build/sync-functions/business-sync/sync-function.js');
+  var businessSyncSpecHelper = businessSyncSpecHelperMaker.init(testFixture);
+
+  afterEach(function() {
+    testFixture.resetTestEnvironment();
+  });
+
+  it('successfully creates a valid wepay auth token document', function() {
+    var doc = {
+      _id: 'biz.4444.wepay.12345.auth',
+      user_id: 12345,
+      access_token: "some-token"
+    };
+
+    testFixture.verifyDocumentAccepted(doc, null, businessSyncSpecHelper.staffChannel);
+  });
+
+  it('cannot create a payment processing attempt document when the properties are invalid', function() {
+    var doc = {
+      _id: 'biz.4444.wepay.12345.auth',
+      user_id: "sfasfd",
+      access_token: ""
+    };
+    expectedErrorMessages = [
+      errorFormatter.typeConstraintViolation('user_id', 'integer'),
+      errorFormatter.mustNotBeEmptyViolation('access_token')
+    ]
+    testFixture.verifyDocumentRejected(doc, null, 'wepayAuthToken', expectedErrorMessages, businessSyncSpecHelper.staffChannel);
+  });
+});


### PR DESCRIPTION
Simple document for caching the entire auth token (currently we only store the token field as part of another document).  This will allow us to keep the whole token, including any expiration time

